### PR TITLE
Capture block using the `&block` syntax

### DIFF
--- a/lib/hubspot_event.rb
+++ b/lib/hubspot_event.rb
@@ -21,12 +21,12 @@ module HubspotEvent
       backend.instrument(namespace.call(event["subscriptionType"]), event) if event
     end
 
-    def subscribe(name, callable = Proc.new)
+    def subscribe(name, &callable)
       backend.subscribe(namespace.to_regexp(name), adapter.call(callable))
     end
 
-    def all(callable = Proc.new)
-      subscribe nil, callable
+    def all(&callable)
+      subscribe nil, &callable
     end
   end
 

--- a/spec/hubspot_event_spec.rb
+++ b/spec/hubspot_event_spec.rb
@@ -2,8 +2,4 @@ RSpec.describe HubspotEvent do
   it "has a version number" do
     expect(HubspotEvent::VERSION).not_to be nil
   end
-
-  it "does something useful" do
-    expect(false).to eq(true)
-  end
 end


### PR DESCRIPTION
Capturing a block using `Proc.new` is deprecated and fails in
ruby >= 3.

Capture the block using the `&block` syntax instead.

Remove generated test